### PR TITLE
stop GDM from attempting to use Wayland

### DIFF
--- a/manjaro-system/manjaro-update-system.sh
+++ b/manjaro-system/manjaro-update-system.sh
@@ -43,6 +43,15 @@ detectDE()
 
 post_upgrade() {
 
+        # stop gdm attempting to use wayland
+        if [ "$(vercmp $2 20151019-1)" -lt 0 ]; then
+		pacman -Qq gdm &> /tmp/cmd1
+		if [[ "$(grep 'gdm' /tmp/cmd1)" == "gdm" ]]; then
+			msg "Stop GDM attempting to use Wayland ..."
+			sed -i -e 's/#WaylandEnable=false/WaylandEnable=false/' /etc/gdm/custom.conf
+		fi
+	fi
+
         # fix the dbus-openrc upgrade and pull in netifrc
         pacman -Qq dbus-openrc &> /tmp/cmd_dbus_rc
 	if [ "$(vercmp $2 20150611)" -gt 0 ] && \


### PR DESCRIPTION
https://forum.manjaro.org/index.php?topic=27567.msg231058#msg231058
https://forum.manjaro.org/index.php?topic=27521.msg230755#msg230755

Some users (seem to be nVidia users) have been left unable to login with the update to GDM 3.18.x
Personally i don't think there's any really good reason for us to have GDM attempting to use Wayland anyway. We don't currently ship any ISO's that actually use Wayland for the DE (by default), so no point in having a DM trying to use it.

I've adjusted the Gnome manjaro-tools-iso profile already.