### PR TITLE
add manjaro-version (QStrings)

### DIFF
--- a/manjaro-release/PKGBUILD
+++ b/manjaro-release/PKGBUILD
@@ -16,5 +16,5 @@ package() {
     # Copy files
     mkdir -p ${pkgdir}/etc
     install -m644 ${srcdir}/lsb-release ${pkgdir}/etc/
-
+    install -m644 ${srcdir}/manjaro-version ${pkgdir}/etc/
 }

--- a/manjaro-release/PKGBUILD
+++ b/manjaro-release/PKGBUILD
@@ -8,7 +8,8 @@ arch=("any")
 url="http://manjarolinux.org/"
 license=('GPL2')
 depends=('lsb-release')
-source=('lsb-release')
+source=('lsb-release'
+	'manjaro-version')
 install="manjaro-release.install"
 sha256sums=('7e1c007d09c2c86e5dcffea984be1deb60d6b614879829c00f179a5cb5b9a968')
 

--- a/manjaro-release/PKGBUILD
+++ b/manjaro-release/PKGBUILD
@@ -11,7 +11,8 @@ depends=('lsb-release')
 source=('lsb-release'
 	'manjaro-version')
 install="manjaro-release.install"
-sha256sums=('7e1c007d09c2c86e5dcffea984be1deb60d6b614879829c00f179a5cb5b9a968')
+sha256sums=('7e1c007d09c2c86e5dcffea984be1deb60d6b614879829c00f179a5cb5b9a968'
+            'eda2d29a78d939c0f3ecc556807c85831a56c98da964e6089f99dfba7c736db4')
 
 package() {
     # Copy files

--- a/manjaro-release/manjaro-version
+++ b/manjaro-release/manjaro-version
@@ -1,0 +1,6 @@
+[Release]
+Release=15.12
+Codename=Capella
+
+[Addition]
+Suffix=


### PR DESCRIPTION
To include the release-info in qt-format would be extremely helpful for my deepin-greeter screen problem [here](https://forum.manjaro.org/index.php?topic=29888.0) and I guess also for other qt-demands in the future.
What do you think?