### PR TITLE
Add Geometry Shaders support for r600/r700

### DIFF
--- a/linux310/PKGBUILD
+++ b/linux310/PKGBUILD
@@ -44,6 +44,7 @@ source=("http://www.kernel.org/pub/linux/kernel/v3.x/linux-${_basekernel}.tar.xz
         'http://sources.gentoo.org/cgi-bin/viewvc.cgi/linux-patches/genpatches-2.6/trunk/3.10/4500_nouveau-video-output-control-Kconfig.patch'
         'criu-no-expert.patch'
         '3.10.13-Revert-zram-use-zram--lock-to-protect-zram_free_page-in-swap-free-notify-path.patch'
+        'r600-r700-allow-geom-rings.patch'
         "0001-block-cgroups-kconfig-build-bits-for-BFQ-${_bfq}.patch::http://algo.ing.unimo.it/people/paolo/disk_sched/patches/3.10.8+-${_bfq}/0001-block-cgroups-kconfig-build-bits-for-BFQ-${_bfq}-3.10.8.patch"
         "0002-block-introduce-the-BFQ-${_bfq}-I-O-sched.patch::http://algo.ing.unimo.it/people/paolo/disk_sched/patches/3.10.8+-${_bfq}/0002-block-introduce-the-BFQ-${_bfq}-I-O-sched-for-3.10.8.patch"
         "0003-block-bfq-add-Early-Queue-Merge-EQM-to-BFQ-${_bfq}.patch::http://algo.ing.unimo.it/people/paolo/disk_sched/patches/3.10.8+-${_bfq}/0003-block-bfq-add-Early-Queue-Merge-EQM-to-BFQ-${_bfq}-for-3.10.8+.patch")
@@ -73,6 +74,7 @@ sha256sums=('df27fa92d27a9c410bfe6c4a89f141638500d7eadcca5cce578954efc2ad3544'
             '59ad742a02bc24d58bc06eee584175a164cb82550b905ba9f402a6dc399d3ed1'
             'daa75228a4c45a925cc5dbfeba884aa696a973a26af7695adc198c396474cbd5'
             '9d7e80e30a60137b9b88dc37d17c65c6834c4e455e9be8db80d98238dfabb1a1'
+            '93d956db561db3519870eb90426267f0de856004cafd58ec086864bdc9032370'
             '41fbe09c3d1b22818fbd5f1e24c4d64cf7b7e935eeed0abd721a9b3bf6e337a4'
             'ac0730dc24529970185ae527e98fb03ee427e1bce44ba9360c4c386ff63792ee'
             '3e818d3dec6a960033668e52b471cc8eaf277ad147d2006fbd73453981c18a91')
@@ -134,6 +136,9 @@ prepare() {
   patch -Np1 -i "${srcdir}/0001-block-cgroups-kconfig-build-bits-for-BFQ-${_bfq}.patch"
   patch -Np1 -i "${srcdir}/0002-block-introduce-the-BFQ-${_bfq}-I-O-sched.patch"
   patch -Np1 -i "${srcdir}/0003-block-bfq-add-Early-Queue-Merge-EQM-to-BFQ-${_bfq}.patch"
+
+  # add Geometry Shaders for r600/r700
+  patch -Np1 -i "${srcdir}/r600-r700-allow-geom-rings.patch"
 
   if [ "${CARCH}" = "x86_64" ]; then
     cat "${srcdir}/config.x86_64" > ./.config

--- a/linux310/r600-r700-allow-geom-rings.patch
+++ b/linux310/r600-r700-allow-geom-rings.patch
@@ -1,0 +1,57 @@
+diff --git a/drivers/gpu/drm/radeon/r600_cs.c b/drivers/gpu/drm/radeon/r600_cs.c
+index 7b399dc..2812c7d1a 100644
+--- a/drivers/gpu/drm/radeon/r600_cs.c
++++ b/drivers/gpu/drm/radeon/r600_cs.c
+@@ -1007,8 +1007,22 @@ static int r600_cs_check_reg(struct radeon_cs_parser *p, u32 reg, u32 idx)
+ 	case R_008C64_SQ_VSTMP_RING_SIZE:
+ 	case R_0288C8_SQ_GS_VERT_ITEMSIZE:
+ 		/* get value to populate the IB don't remove */
+-		tmp =radeon_get_ib_value(p, idx);
+-		ib[idx] = 0;
++		/*tmp =radeon_get_ib_value(p, idx);
++		  ib[idx] = 0;*/
++		break;
++	case SQ_ESGS_RING_BASE:
++	case SQ_GSVS_RING_BASE:
++	case SQ_ESTMP_RING_BASE:
++	case SQ_GSTMP_RING_BASE:
++	case SQ_PSTMP_RING_BASE:
++	case SQ_VSTMP_RING_BASE:
++		r = radeon_cs_packet_next_reloc(p, &reloc, 0);
++		if (r) {
++			dev_warn(p->dev, "bad SET_CONTEXT_REG "
++					"0x%04X\n", reg);
++			return -EINVAL;
++		}
++		ib[idx] += (u32)((reloc->lobj.gpu_offset >> 8) & 0xffffffff);
+ 		break;
+ 	case SQ_CONFIG:
+ 		track->sq_config = radeon_get_ib_value(p, idx);
+diff --git a/drivers/gpu/drm/radeon/radeon_drv.c b/drivers/gpu/drm/radeon/radeon_drv.c
+index ec8c388..84a1bbb7 100644
+--- a/drivers/gpu/drm/radeon/radeon_drv.c
++++ b/drivers/gpu/drm/radeon/radeon_drv.c
+@@ -78,9 +78,10 @@
+  *   2.34.0 - Add CIK tiling mode array query
+  *   2.35.0 - Add CIK macrotile mode array query
+  *   2.36.0 - Fix CIK DCE tiling setup
++ *   2.37.0 - allow GS ring setup on r6xx/r7xx
+  */
+ #define KMS_DRIVER_MAJOR	2
+-#define KMS_DRIVER_MINOR	36
++#define KMS_DRIVER_MINOR	37
+ #define KMS_DRIVER_PATCHLEVEL	0
+ int radeon_driver_load_kms(struct drm_device *dev, unsigned long flags);
+ int radeon_driver_unload_kms(struct drm_device *dev);
+diff --git a/drivers/gpu/drm/radeon/reg_srcs/r600 b/drivers/gpu/drm/radeon/reg_srcs/r600
+index 20bfbda..ec0c682 100644
+--- a/drivers/gpu/drm/radeon/reg_srcs/r600
++++ b/drivers/gpu/drm/radeon/reg_srcs/r600
+@@ -18,6 +18,7 @@ r600 0x9400
+ 0x00028A3C VGT_GROUP_VECT_1_FMT_CNTL
+ 0x00028A40 VGT_GS_MODE
+ 0x00028A6C VGT_GS_OUT_PRIM_TYPE
++0x00028B38 VGT_GS_MAX_VERT_OUT
+ 0x000088C8 VGT_GS_PER_ES
+ 0x000088E8 VGT_GS_PER_VS
+ 0x000088D4 VGT_GS_VERTEX_REUSE

--- a/linux312/PKGBUILD
+++ b/linux312/PKGBUILD
@@ -44,6 +44,7 @@ source=("http://www.kernel.org/pub/linux/kernel/v3.x/linux-${_basekernel}.tar.xz
         'nfs-check-gssd-running-before-krb5i-auth.patch'
         'rpc_pipe-fix-cleanup-of-dummy-gssd-directory-when-notification-fails.patch'
         'rpc_pipe-remove-the-clntXX-dir-if-creating-the-pipe-fails.patch'
+        'r600-r700-allow-geom-rings.patch'
         'sunrpc-add-an-info-file-for-the-dummy-gssd-pipe.patch'
         'sunrpc-create-a-new-dummy-pipe-for-gssd-to-hold-open.patch'
         'sunrpc-replace-gssd_running-with-more-reliable-check.patch'
@@ -76,6 +77,7 @@ sha256sums=('2e120ec7fde19fa51dc6b6cc11c81860a0775defcad5a5bf910ed9a50e845a02'
             '139d576c540840fe18b0ce8468c243011e5f8b4aebfb1a288afe10b9f8d88137'
             'fecca9a761f3427c7f2f793e5d9a34d6f43799143e9a6b51edc372f88c76022e'
             'c045ce9c2571c4e6ff63345ea9abd9f778f56206f686b95491523ac740458420'
+            '93d956db561db3519870eb90426267f0de856004cafd58ec086864bdc9032370'
             'd8d6745a165e7f1608d8c298e49c8c2fee5a5d6c61c5b80d63a8dc7913ff8dc8'
             'b6f366ed2100ccab99029f61c39c0781ad4863f537381626196ed43b4b115a21'
             'cbfabd113a1954cd3d6cc1e70c19b95ce36a19e2c92ad93939d4982077178135'
@@ -146,6 +148,9 @@ prepare() {
   patch -Np1 -i "${srcdir}/0001-block-cgroups-kconfig-build-bits-for-BFQ-${_bfq}.patch"
   patch -Np1 -i "${srcdir}/0002-block-introduce-the-BFQ-${_bfq}-I-O-sched.patch"
   patch -Np1 -i "${srcdir}/0003-block-bfq-add-Early-Queue-Merge-EQM-to-BFQ-${_bfq}.patch"
+
+  # add Geometry Shaders for r600/r700
+  patch -Np1 -i "${srcdir}/r600-r700-allow-geom-rings.patch"
 
   if [ "${CARCH}" = "x86_64" ]; then
     cat "${srcdir}/config.x86_64" > ./.config

--- a/linux312/r600-r700-allow-geom-rings.patch
+++ b/linux312/r600-r700-allow-geom-rings.patch
@@ -1,0 +1,57 @@
+diff --git a/drivers/gpu/drm/radeon/r600_cs.c b/drivers/gpu/drm/radeon/r600_cs.c
+index 7b399dc..2812c7d1a 100644
+--- a/drivers/gpu/drm/radeon/r600_cs.c
++++ b/drivers/gpu/drm/radeon/r600_cs.c
+@@ -1007,8 +1007,22 @@ static int r600_cs_check_reg(struct radeon_cs_parser *p, u32 reg, u32 idx)
+ 	case R_008C64_SQ_VSTMP_RING_SIZE:
+ 	case R_0288C8_SQ_GS_VERT_ITEMSIZE:
+ 		/* get value to populate the IB don't remove */
+-		tmp =radeon_get_ib_value(p, idx);
+-		ib[idx] = 0;
++		/*tmp =radeon_get_ib_value(p, idx);
++		  ib[idx] = 0;*/
++		break;
++	case SQ_ESGS_RING_BASE:
++	case SQ_GSVS_RING_BASE:
++	case SQ_ESTMP_RING_BASE:
++	case SQ_GSTMP_RING_BASE:
++	case SQ_PSTMP_RING_BASE:
++	case SQ_VSTMP_RING_BASE:
++		r = radeon_cs_packet_next_reloc(p, &reloc, 0);
++		if (r) {
++			dev_warn(p->dev, "bad SET_CONTEXT_REG "
++					"0x%04X\n", reg);
++			return -EINVAL;
++		}
++		ib[idx] += (u32)((reloc->lobj.gpu_offset >> 8) & 0xffffffff);
+ 		break;
+ 	case SQ_CONFIG:
+ 		track->sq_config = radeon_get_ib_value(p, idx);
+diff --git a/drivers/gpu/drm/radeon/radeon_drv.c b/drivers/gpu/drm/radeon/radeon_drv.c
+index ec8c388..84a1bbb7 100644
+--- a/drivers/gpu/drm/radeon/radeon_drv.c
++++ b/drivers/gpu/drm/radeon/radeon_drv.c
+@@ -78,9 +78,10 @@
+  *   2.34.0 - Add CIK tiling mode array query
+  *   2.35.0 - Add CIK macrotile mode array query
+  *   2.36.0 - Fix CIK DCE tiling setup
++ *   2.37.0 - allow GS ring setup on r6xx/r7xx
+  */
+ #define KMS_DRIVER_MAJOR	2
+-#define KMS_DRIVER_MINOR	36
++#define KMS_DRIVER_MINOR	37
+ #define KMS_DRIVER_PATCHLEVEL	0
+ int radeon_driver_load_kms(struct drm_device *dev, unsigned long flags);
+ int radeon_driver_unload_kms(struct drm_device *dev);
+diff --git a/drivers/gpu/drm/radeon/reg_srcs/r600 b/drivers/gpu/drm/radeon/reg_srcs/r600
+index 20bfbda..ec0c682 100644
+--- a/drivers/gpu/drm/radeon/reg_srcs/r600
++++ b/drivers/gpu/drm/radeon/reg_srcs/r600
+@@ -18,6 +18,7 @@ r600 0x9400
+ 0x00028A3C VGT_GROUP_VECT_1_FMT_CNTL
+ 0x00028A40 VGT_GS_MODE
+ 0x00028A6C VGT_GS_OUT_PRIM_TYPE
++0x00028B38 VGT_GS_MAX_VERT_OUT
+ 0x000088C8 VGT_GS_PER_ES
+ 0x000088E8 VGT_GS_PER_VS
+ 0x000088D4 VGT_GS_VERTEX_REUSE


### PR DESCRIPTION
I propose to add useful patch which adds **Geometry Shaders** features _for AMD r600/r700 chips_ in **linux310** and **linux312** kernels. Patch created by Dave Airlie (v1) and Alex Deucher (v2: cleanup and r700 support). These changes _are already included_ in kernel>=3.14-rc2 (https://github.com/torvalds/linux/commit/7c4c62a04a2a80e3feb5d6c97aca1e413b11c790).

More info can be find at:
https://www.spinics.net/lists/dri-devel/msg52745.html