### PR TITLE
Solve dependency problem with dbus-c++

### DIFF
--- a/dbus-x11/PKGBUILD
+++ b/dbus-x11/PKGBUILD
@@ -7,7 +7,7 @@
 pkgname=dbus-x11
 _pkgname=dbus
 pkgver=1.10.10
-pkgrel=3.2
+pkgrel=3.3
 pkgdesc="Freedesktop.org message bus system"
 url="https://wiki.freedesktop.org/www/Software/dbus/"
 arch=(i686 x86_64)

--- a/dbus-x11/PKGBUILD
+++ b/dbus-x11/PKGBUILD
@@ -12,7 +12,7 @@ pkgdesc="Freedesktop.org message bus system"
 url="https://wiki.freedesktop.org/www/Software/dbus/"
 arch=(i686 x86_64)
 license=(GPL custom)
-provides=('libdbus' 'dbus')
+provides=('libdbus' "dbus=$pkgver")
 conflicts=('libdbus' 'dbus')
 #replaces=(libdbus)
 depends=(libsystemd expat)


### PR DESCRIPTION
Solve the problem that pacman don't see dbus-x11 as valid for dbus-c++ dependency asking dbus>=1.2.0

I don't know if it's the best solution.