### PR TITLE
Turn off the GTK error bell globally

### DIFF
--- a/filesystem/profile
+++ b/filesystem/profile
@@ -1,6 +1,6 @@
 # /etc/profile
 
-#Set our umask
+# Set our umask
 umask 022
 
 # Set our default path
@@ -14,6 +14,9 @@ if test -d /etc/profile.d/; then
 	done
 	unset profile
 fi
+
+# Turn off GTK beeps
+xset b off
 
 # Source global bash config
 if test "$PS1" && test "$BASH" && test -z ${POSIXLY_CORRECT+x} && test -r /etc/bash.bashrc; then


### PR DESCRIPTION
This change will globally disable the GTK error bell, which is so jarring and horrible that it lengthened the process of convinving my wife to switch to Linux (no lie).