### PR TITLE
Enable avahis local hostname resolution

### DIFF
--- a/filesystem/nsswitch.conf
+++ b/filesystem/nsswitch.conf
@@ -6,7 +6,7 @@ shadow: compat
 
 publickey: files
 
-hosts: files mymachines resolve [!UNAVAIL=return] dns myhostname
+hosts: files mymachines mdns4_minimal [NOTFOUND=return] resolve [!UNAVAIL=return] dns myhostname
 networks: files
 
 protocols: files


### PR DESCRIPTION
Multiple users have requested this in the forums: 

https://forum.manjaro.org/t/avahi-add-mdns4-minimal-in-nsswitch-conf/32288

This apparently makes installation play nice out of the box with some wireless printers and android ftp servers. This tweak enables avahis local hostname resolution, as described in https://wiki.archlinux.org/index.php/Avahi#Hostname_resolution

I know the matter poorly myself, so I would like to bring this to discussion.