### PR TITLE
 +vega support

### DIFF
--- a/mhwd-amdgpu/PKGBUILD
+++ b/mhwd-amdgpu/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Fabian Bornschein <plusfabi[at]gmail[dog]com>
 
 pkgname=('mhwd-amdgpu')
-pkgver=1.2.0
+pkgver=1.2.1
 pkgrel=2
 
 pkgdesc="MHWD module-ids for amdgpu"
@@ -30,8 +30,8 @@ prepare() {
                    "Polaris12"
                    "Baffin"
                    "Ellesmere"
-                   "Lexa")
-#                   "Vega")
+                   "Lexa"
+                   "Vega")
 
     AMD_DEVNAMES_EXP=("Chelsea"
                     "Cape Verde"

--- a/mhwd-amdgpu/PKGBUILD
+++ b/mhwd-amdgpu/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=('mhwd-amdgpu')
 pkgver=1.2.1
-pkgrel=2
+pkgrel=1
 
 pkgdesc="MHWD module-ids for amdgpu"
 arch=('any')


### PR DESCRIPTION
Vega hardware is now available, so it would be a good idea to activate this in mhwd before we ship the 17.1 release