### PR TITLE
Manjaro system

### DIFF
--- a/manjaro-system/PKGBUILD
+++ b/manjaro-system/PKGBUILD
@@ -5,8 +5,9 @@
 # Contributor: Alexandru Ianu <alexandru[at]manjaro[dot]org>
 
 pkgname=manjaro-system
-pkgver=$(date +%Y%m%d)
-pkgrel=2
+#pkgver=$(date +%Y%m%d)
+pkgver=20171227
+pkgrel=1
 pkgdesc="Manjaro Linux System - Update script"
 arch=('any')
 url="http://www.manjaro.org"

--- a/manjaro-system/manjaro-update-system.sh
+++ b/manjaro-system/manjaro-update-system.sh
@@ -41,6 +41,25 @@ detectDE()
 }
 
 post_upgrade() {
+	# Switch i686 to x32-* branch and install keys
+	if [[ "$(vercmp $2 20171227)" -lt 0 ]] && [[ "$(uname -m)" == "i686" ]]; then
+		msg "Switching mirrors and keyrings to manjaro32..."
+
+		# Switch branch
+		sed -i '/x32/! s|#?Branch = \(.*\)|Branch = x32-\1|' /etc/pacman-mirrors.conf
+
+		# Install transition keyring; if archlinux32-keyring already exists
+		# this will "fail", but that's OK
+		pacman --noconfirm -S archlinux32-keyring-transition || true
+
+		# Install that new keyring, say yes to replace the transition keyring
+		yes | pacman --noconfirm -S archlinux32-keyring
+
+		# Make sure the keyrings are populated and refreshed
+		pacman-key --populate archlinux32 manjaro
+		pacman-key --refresh-keys
+	fi
+
 	# Fix upgrading sddm version is 0.17.0-3 or less
 	pacman -Q sddm &> /tmp/cmd1
 	if [ "$(grep 'sddm' /tmp/cmd1 | cut -d' ' -f1)" == "sddm" ]; then 

--- a/manjaro-system/manjaro-update-system.sh
+++ b/manjaro-system/manjaro-update-system.sh
@@ -60,7 +60,7 @@ post_upgrade() {
 		pacman --noconfirm -S archlinux32-keyring-transition || true
 
 		# Install that new keyring, say yes to replace the transition keyring
-		yes | pacman --noconfirm -S archlinux32-keyring
+		yes | pacman -S archlinux32-keyring
 
 		# Make sure the keyrings are populated and refreshed
 		pacman-key --populate archlinux32 manjaro

--- a/manjaro-system/manjaro-update-system.sh
+++ b/manjaro-system/manjaro-update-system.sh
@@ -46,7 +46,7 @@ post_upgrade() {
 		msg "Switching mirrors and keyrings to manjaro32..."
 
 		# Switch branch
-		sed -i '/x32/! s|#?Branch = \(.*\)|Branch = x32-\1|' /etc/pacman-mirrors.conf
+		sed -i '/x32/! s|Branch = \(.*\)|Branch = x32-\1|' /etc/pacman-mirrors.conf
 
 		# Install transition keyring; if archlinux32-keyring already exists
 		# this will "fail", but that's OK

--- a/manjaro-system/manjaro-update-system.sh
+++ b/manjaro-system/manjaro-update-system.sh
@@ -47,6 +47,10 @@ post_upgrade() {
 
 		# Switch branch
 		sed -i '/x32/! s|Branch = \(.*\)|Branch = x32-\1|' /etc/pacman-mirrors.conf
+		
+		# Update the mirror list
+		pacman-mirrors -f 0
+		pacman -Syy
 
 		# Install transition keyring; if archlinux32-keyring already exists
 		# this will "fail", but that's OK

--- a/manjaro-system/manjaro-update-system.sh
+++ b/manjaro-system/manjaro-update-system.sh
@@ -50,6 +50,9 @@ post_upgrade() {
 		
 		# Update the mirror list
 		pacman-mirrors -f 0
+		
+		# Hacky hack is hacky, but there's no other way?
+		rm /var/lib/pacman/db.lck &> /dev/null
 		pacman -Syy
 
 		# Install transition keyring; if archlinux32-keyring already exists


### PR DESCRIPTION
This adds some automation to allow i686 systems to transition to the archlinux32 keyrings and use the x32-* repo branches.