### PR TITLE
Patch Upstream patch with forward option -N so it did not get reversed

### DIFF
--- a/linux414/PKGBUILD
+++ b/linux414/PKGBUILD
@@ -123,7 +123,7 @@ prepare() {
   cd "${srcdir}/linux-${_basekernel}"
 
   # add upstream patch
-  patch -p1 -i "${srcdir}/patch-${pkgver}"
+  patch -Np1 -i "${srcdir}/patch-${pkgver}"
   chmod +x tools/objtool/sync-check.sh # GNU patch doesn't support git-style file mode
 
   # add latest fixes from stable queue, if needed


### PR DESCRIPTION
Build the Kernel then edited the .config
The second in-tree build fails with patch verbose question whether to reverse the upstream patch.
The forward patch Option -N assumes no reverse heuristic have to be tested. 
Which is obviously on a upstream patch. IMHO